### PR TITLE
fix: replace non-descriptive link text to satisfy MD059 lint rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,14 @@
 
 > To get started...
 
-- 🍴 Fork this repo [here](https://github.com/FrancesCoronel/diversify-me#fork-destination-box)
+- 🍴 [Fork this repo](https://github.com/FrancesCoronel/diversify-me#fork-destination-box)
 - 🔨 Hack away
 - 😊 Add yourself as a contributor under credits
-- 🔧 Make a pull request [here](https://github.com/FrancesCoronel/diversify-me/compare)
+- 🔧 [Make a pull request](https://github.com/FrancesCoronel/diversify-me/compare)
 
 > Or just create an issue - any little bit of help counts! 😊
 
-- 😯 Create an issue [here](https://github.com/FrancesCoronel/diversify-me/issues)!
+- 😯 [Create an issue](https://github.com/FrancesCoronel/diversify-me/issues)!
 
 When submitting a pull request to add a conference(s), please follow the formatting below:
 

--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ More details can be found at this project's [code of conduct](.github/CODE_OF_CO
 
 > To get started...
 
-- 🍴 Fork this repo [here](https://github.com/FrancesCoronel/diversify-me#fork-destination-box)
+- 🍴 [Fork this repo](https://github.com/FrancesCoronel/diversify-me#fork-destination-box)
 - 🔨 Hack away
 - 😊 Add yourself as a contributor under credits
-- 🔧 Make a pull request [here](https://github.com/FrancesCoronel/diversify-me/compare)
+- 🔧 [Make a pull request](https://github.com/FrancesCoronel/diversify-me/compare)
 
 > Or just create an issue - any little bit of help counts! 😊
 
-- 😯 Create an issue [here](https://github.com/FrancesCoronel/diversify-me/issues)!
+- 😯 [Create an issue](https://github.com/FrancesCoronel/diversify-me/issues)!
 
 When submitting a pull request to add a conference(s), please follow the formatting below:
 


### PR DESCRIPTION
## Summary

- markdownlint v0.40.0 (shipped in `DavidAnson/markdownlint-cli2-action@v23`) added rule MD059 which flags generic `[here]` link text
- Replaced all 6 instances in `CONTRIBUTING.md` and `README.md` with descriptive inline links
- This unblocks PR #23 (markdownlint-cli2-action bump) which currently fails Lint CI

## Test plan

- [ ] Lint CI passes on this PR
- [ ] After merging to master, trigger Dependabot rebase on PR #23 to confirm it goes green

https://claude.ai/code/session_012vGLaFFqrfQgGTyeMR7A4X

---
_Generated by [Claude Code](https://claude.ai/code/session_012vGLaFFqrfQgGTyeMR7A4X)_